### PR TITLE
Bandit and bugbear

### DIFF
--- a/count_timer/old_demos/demo_thread.py
+++ b/count_timer/old_demos/demo_thread.py
@@ -60,6 +60,7 @@ def count():
 def take_input():
     while counter.remaining > 0:
         with term.cbreak():
+            _ = term.inkey()
             counter.pause() if counter.running else counter.resume()
 
 


### PR DESCRIPTION
Fix whining from flake8, flake8-bugbear, and flake8-bandit.
Add a .flake8 configuration file to keep from having to fix too many things:
- lengthen the default line
- don't whine about how lines are broken around binary operators
- don't complain about the use of asserts by unit tests.
- permit the current maximum, McCabe complexity level (this should be looked at, just not now.)