### PR TITLE
Arbitrary start

### DIFF
--- a/count_timer/count_timer.py
+++ b/count_timer/count_timer.py
@@ -17,7 +17,8 @@ class CountTimer:
         start(): start the timer
         pause(): pause the timer
         resume(): resume the timer
-        set_start_time(minutes): set the start time manually in minutes
+        set_minutes_start_time(minutes): set the start time manually in minutes
+        set_seconds_start_time(seconds): set the start time manually in seconds
         reset(): reset the timer to default (duration 0/paused/not started)
 
     Properties:
@@ -64,9 +65,15 @@ class CountTimer:
         self._time_started = self._time_started + pause_duration
         self._paused = False
 
-    def set_start_time(self, minutes):
+    def set_minutes_start_time(self, minutes):
         """Set the start time manually in minutes."""
         self._time_started = time.time() - (minutes * 60)
+        self._time_paused = time.time()
+        self._paused = True
+
+    def set_seconds_start_time(self, seconds):
+        """Set the start time manually in minutes."""
+        self._time_started = time.time() - seconds
         self._time_paused = time.time()
         self._paused = True
 

--- a/count_timer/count_timer.py
+++ b/count_timer/count_timer.py
@@ -17,6 +17,7 @@ class CountTimer:
         start(): start the timer
         pause(): pause the timer
         resume(): resume the timer
+        set_start_time(minutes): set the start time manually in minutes
         reset(): reset the timer to default (duration 0/paused/not started)
 
     Properties:
@@ -62,6 +63,12 @@ class CountTimer:
         pause_duration = time.time() - self._time_paused
         self._time_started = self._time_started + pause_duration
         self._paused = False
+
+    def set_start_time(self, minutes):
+        """Set the start time manually in minutes."""
+        self._time_started = time.time() - (minutes * 60)
+        self._time_paused = time.time()
+        self._paused = True
 
     def _get(self) -> float:
         """Time in sec since timer was started, minus any time paused."""


### PR DESCRIPTION
I added the ability to set the minutes or seconds from which to start the timer in the case of a count-up.

use:

counter.set_minutes_start_time(minutes)
counter.start()

For the sake of speed, I reused the pause() function, so it's as if a resume() is executed when .start() is called.

Manual minutes set:
![image](https://github.com/jeffwright13/count-timer/assets/24323132/9369aa25-f259-443e-b8f7-eafdce822de2)

The timer starts from the set minutes
![image](https://github.com/jeffwright13/count-timer/assets/24323132/060a0155-4332-419f-b465-d9fa0937e58c)




